### PR TITLE
(feat) Convert assertion comments into usable format [Closes #4]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     eslint: {
-      src: ['speck.js', 'Gruntfile.js', 'parsing/**/*.js’]
+      src: ['speck.js', 'Gruntfile.js', 'parsing/**/*.js']
     },
     watch: {
       files: ['<%= eslint.src %>'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     eslint: {
-      src: ['speck.js', 'Gruntfile.js']
+      src: ['speck.js', 'Gruntfile.js', 'parsing/**/*.js’]
     },
     watch: {
       files: ['<%= eslint.src %>'],

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "grunt": "^0.4.5",
     "grunt-contrib-watch": "^0.6.1",
     "gruntify-eslint": "^1.0.1"
+  },
+  "dependencies": {
+    "extract-values": "^0.1.2"
   }
 }

--- a/parsing/comment-conversion.js
+++ b/parsing/comment-conversion.js
@@ -2,7 +2,9 @@ var extractValues = require('extract-values');
 
 var assertionTypeMap = {
   '==': 'equal',
-  '===': 'deepEqual'
+  '===': 'deepEqual',
+  '!==': 'notEqual',
+  '!===': 'notDeepEqual'
 };
 
 //Helper takes string as an input, matches to hash map and returns the converted value
@@ -11,20 +13,19 @@ var convertAssertionType = function(type) {
 };
 
 var extractTestDetails = function(parsedAssertions) {
-  var extractedAssertions = [];
   var assertionParts;
 
   //Loop over all assertions and use pattern matching to extract the atomic units
-  parsedAssertions.forEach(function(assertion) {
+  return parsedAssertions.map(function(assertion) {
     assertionParts = extractValues(assertion, '{assertionInput} {assertionType} {assertionOutput} ({assertionMessage})');
 
     //Convert assertion type from symbol to usable syntax
     assertionParts.assertionType = convertAssertionType(assertionParts.assertionType);
-    extractedAssertions.push(assertionParts);
+    return assertionParts;
   });
-
-  return extractedAssertions;
 };
+
+// console.log(extractTestDetails(test));
 
 module.exports = {
   extractTestDetails: extractTestDetails

--- a/parsing/comment-conversion.js
+++ b/parsing/comment-conversion.js
@@ -10,26 +10,20 @@ var convertAssertionType = function(type) {
   return assertionTypeMap[type];
 };
 
-var extractTestDetails = function(parsedComment) {
-  var extractedDetails = {};
-
-  //Matches pattern of the test line to get just the title of the test
-  var testLineParts = extractValues(parsedComment.testLine, '{type} > {testTitle}');
-  extractedDetails.testTitle = testLineParts.testTitle;
-
-  extractedDetails.assertions = [];
+var extractTestDetails = function(parsedAssertions) {
+  var extractedAssertions = [];
   var assertionParts;
 
   //Loop over all assertions and use pattern matching to extract the atomic units
-  parsedComment.assertions.forEach(function(assertion) {
+  parsedAssertions.forEach(function(assertion) {
     assertionParts = extractValues(assertion, '{assertionInput} {assertionType} {assertionOutput} ({assertionMessage})');
 
     //Convert assertion type from symbol to usable syntax
     assertionParts.assertionType = convertAssertionType(assertionParts.assertionType);
-    extractedDetails.assertions.push(assertionParts);
+    extractedAssertions.push(assertionParts);
   });
 
-  return extractedDetails;
+  return extractedAssertions;
 };
 
 module.exports = {

--- a/parsing/comment-conversion.js
+++ b/parsing/comment-conversion.js
@@ -1,5 +1,15 @@
 var extractValues = require('extract-values');
 
+var assertionTypeMap = {
+  '==': 'equal',
+  '===': 'deepEqual'
+};
+
+//Helper takes string as an input, matches to hash map and returns the converted value
+var convertAssertionType = function(type) {
+  return assertionTypeMap[type];
+};
+
 var extractTestDetails = function(parsedComment) {
   var extractedDetails = {};
 
@@ -13,6 +23,9 @@ var extractTestDetails = function(parsedComment) {
   //Loop over all assertions and use pattern matching to extract the atomic units
   parsedComment.assertions.forEach(function(assertion) {
     assertionParts = extractValues(assertion, '{assertionInput} {assertionType} {assertionOutput} ({assertionMessage})');
+
+    //Convert assertion type from symbol to usable syntax
+    assertionParts.assertionType = convertAssertionType(assertionParts.assertionType);
     extractedDetails.assertions.push(assertionParts);
   });
 

--- a/parsing/comment-conversion.js
+++ b/parsing/comment-conversion.js
@@ -1,25 +1,24 @@
 var extractValues = require('extract-values');
 
 var extractTestDetails = function(parsedComment) {
-  var extractedDetails = {}
+  var extractedDetails = {};
+
+  //Matches pattern of the test line to get just the title of the test
+  var testLineParts = extractValues(parsedComment.testLine, '{type} > {testTitle}');
+  extractedDetails.testTitle = testLineParts.testTitle;
+
+  extractedDetails.assertions = [];
+  var assertionParts;
+
+  //Loop over all assertions and use pattern matching to extract the atomic units
+  parsedComment.assertions.forEach(function(assertion) {
+    assertionParts = extractValues(assertion, '{assertionInput} {assertionType} {assertionOutput} ({assertionMessage})');
+    extractedDetails.assertions.push(assertionParts);
+  });
 
   return extractedDetails;
 };
 
-
-
-//-----------------------EXPECTED OUTPUT--------------------------------
-// { testTitle: 'sum function',
-//   assertions: [
-//     { assertionMessage: 'return the sum of both params',
-//       assertionType: 'equal',
-//       assertionInput: 'sum(1, 3)',
-//       assertionOutput: '4'
-//     }
-//   ]
-// }
-
-
 module.exports = {
-  extractTestDetails: extractTestDetails;
+  extractTestDetails: extractTestDetails
 };

--- a/parsing/comment-conversion.js
+++ b/parsing/comment-conversion.js
@@ -1,0 +1,25 @@
+var extractValues = require('extract-values');
+
+var extractTestDetails = function(parsedComment) {
+  var extractedDetails = {}
+
+  return extractedDetails;
+};
+
+
+
+//-----------------------EXPECTED OUTPUT--------------------------------
+// { testTitle: 'sum function',
+//   assertions: [
+//     { assertionMessage: 'return the sum of both params',
+//       assertionType: 'equal',
+//       assertionInput: 'sum(1, 3)',
+//       assertionOutput: '4'
+//     }
+//   ]
+// }
+
+
+module.exports = {
+  extractTestDetails: extractTestDetails;
+};


### PR DESCRIPTION
There are a few functions in this file, one helper and the main function that I'll be exporting is `extractTestDetails`. This will take in an array of assertions that have already been parsed from the source file and will output an object with the atomic units of a Tape test.

## Example
Input
```
[
  'sum(1,3) == 4 (return the sum of both params)',
  'sum(10,10) == 20 (return the sum of both params)' 
];
```

Output
```
[ 
  { 
    assertionInput: ' sum(1,3)',
    assertionType: 'equal',
    assertionOutput: '4',
    assertionMessage: 'return the sum of both params' 
  },
  { 
    assertionInput: ' sum(10,10)',
    assertionType: 'equal',
    assertionOutput: '20',
    assertionMessage: 'return the sum of both params' 
  }
]
```