### PR TITLE
Feature/template util fx. [Closes #12]

### DIFF
--- a/templates/template-utils.js
+++ b/templates/template-utils.js
@@ -1,10 +1,13 @@
+var dot = require('dot');
+var tapeTemps = require('./tape-templates.js');
+
 /*
   Function that transforms an object into JavaScript test code.
   input:  (String) base-template to build upon with each test and its respective assertions.
   input:  (Object) test data from parsed comments.
   output: (String) interpolated test block.
 */
-var addTestDataToBaseTemplate = function(baseTemp, data) {
+exports.addTestDataToBaseTemplate = function(baseTemp, data) {
   var tests = data.tests;
   var result = '';
 
@@ -24,7 +27,7 @@ var addTestDataToBaseTemplate = function(baseTemp, data) {
     }
 
     // Close currentTest block and add to result
-    result += currentTest + "}); \n";
+    result += currentTest + '}); \n';
   }
 
   // Return string representing interpolated test block

--- a/templates/template-utils.js
+++ b/templates/template-utils.js
@@ -1,0 +1,32 @@
+/*
+  Function that transforms an object into JavaScript test code.
+  input:  (String) base-template to build upon with each test and its respective assertions.
+  input:  (Object) test data from parsed comments.
+  output: (String) interpolated test block.
+*/
+var addTestDataToBaseTemplate = function(baseTemp, data) {
+  var tests = data.tests;
+  var result = '';
+
+  // For each test
+  for (var i=0; i < tests.length; i++) {
+    // Add title and assertion count to baseTemp
+    var currentTest = dot.template(baseTemp)({testTitle: tests[i].testTitle,
+                                              assertions: tests[i].assertions.length}) + '\n';
+
+    // For each assertion in test
+    for (var j=0; j < tests[i].assertions.length; j++) {
+      var tempToAdd = tapeTemps[tests[i].assertions[j].assertionType];
+      var compiledAssertToAdd = dot.template(tempToAdd)(tests[i].assertions[j]);
+
+      // Add filled-in template to currentTest
+      currentTest += compiledAssertToAdd + '\n';
+    }
+
+    // Close currentTest block and add to result
+    result += currentTest + "}); \n";
+  }
+
+  // Return string representing interpolated test block
+  return result;
+};


### PR DESCRIPTION
Though we have no immediate use for the templating library nor our templates, this file requires we have ```dot``` and ```tape``` in this file in order to pass our linting, as we're referencing them inside of the function.