### PR TITLE
Jasmine test templates do not have proper assertions [Closes #57]

### DIFF
--- a/templates/jasmine/jasmine-templates.js
+++ b/templates/jasmine/jasmine-templates.js
@@ -5,8 +5,8 @@ var tempRequire = 'var {{=it.varName}} = require(\'{{=it.module}}\');';
 var baseTemplate = 'describe(\'{{=it.testTitle}}\', function() { ';
 
 // Individual assertion templates
-var equalTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}{{=it.assertionType}}({{=it.assertionOutput}}))\n});';
-var notEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}{{=it.assertionType}}({{=it.assertionOutput}}))\n});';
+var equalTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}.toBe({{=it.assertionOutput}}))\n});';
+var notEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}.not.toBe({{=it.assertionOutput}}))\n});';
 
 module.exports = {
   require: tempRequire,


### PR DESCRIPTION
There was a small bug in how the assertion types were being printed out. With Jasmine I had to change it to explicitly use Jasmine syntax instead of just injecting the assertionType into the template.