### PR TITLE
Implement deepEqual/notDeepEqual in Jasmine [Closes #45]

### DIFF
--- a/templates/jasmine/jasmine-templates.js
+++ b/templates/jasmine/jasmine-templates.js
@@ -1,5 +1,6 @@
 // Utility templates
 var tempRequire = 'var {{=it.varName}} = require(\'{{=it.module}}\');';
+var assertRequire = 'var assert = require(\'assert\');';
 
 // Base template
 var baseTemplate = 'describe(\'{{=it.testTitle}}\', function() { ';
@@ -7,13 +8,15 @@ var baseTemplate = 'describe(\'{{=it.testTitle}}\', function() { ';
 // Individual assertion templates
 var equalTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}.toBe({{=it.assertionOutput}}))\n});';
 var notEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}.not.toBe({{=it.assertionOutput}}))\n});';
+var deepEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nvar pass;\ntry {\npass = true;\nassert.deepEqual(file.{{=it.assertionInput}}, {{=it.assertionOutput}});\n} catch (e) {\npass = false;\n}\nexpect(pass).toBe(true);\n});\n';
 
 module.exports = {
   require: tempRequire,
+  assert: assertRequire,
   base: baseTemplate,
   equal: equalTemplate,
-  notEqual: notEqualTemplate
+  notEqual: notEqualTemplate,
+  deepEqual: deepEqualTemplate
   //Commented these out since we will be implementing them soon
-  //deepEqual: deepEqualTemplate,
   //notDeepEqual: notDeepEqualTemplate
 };

--- a/templates/jasmine/jasmine-templates.js
+++ b/templates/jasmine/jasmine-templates.js
@@ -9,6 +9,7 @@ var baseTemplate = 'describe(\'{{=it.testTitle}}\', function() { ';
 var equalTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}.toBe({{=it.assertionOutput}}))\n});';
 var notEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}.not.toBe({{=it.assertionOutput}}))\n});';
 var deepEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nvar pass;\ntry {\npass = true;\nassert.deepEqual(file.{{=it.assertionInput}}, {{=it.assertionOutput}});\n} catch (e) {\npass = false;\n}\nexpect(pass).toBe(true);\n});\n';
+var notDeepEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nvar pass;\ntry {\npass = true;\nassert.notDeepEqual(file.{{=it.assertionInput}}, {{=it.assertionOutput}});\n} catch (e) {\npass = false;\n}\nexpect(pass).toBe(true);\n});\n';
 
 module.exports = {
   require: tempRequire,
@@ -16,7 +17,6 @@ module.exports = {
   base: baseTemplate,
   equal: equalTemplate,
   notEqual: notEqualTemplate,
-  deepEqual: deepEqualTemplate
-  //Commented these out since we will be implementing them soon
-  //notDeepEqual: notDeepEqualTemplate
+  deepEqual: deepEqualTemplate,
+  notDeepEqual: notDeepEqualTemplate
 };


### PR DESCRIPTION
I used the node.js assert module to create some boilerplate code within the templates for Jasmine. As a result, now the Jasmine tests include assertions for `deepEqual` and `notDeepEqual`.