### PR TITLE
Modularized plan template from base to fix formatting issues [Closes #68]

### DIFF
--- a/speck.js
+++ b/speck.js
@@ -44,7 +44,7 @@ var build = function build(file, options) {
         jsTestString = tempUtils.addTestDataToBaseTemplateJasmine(utilData, jasmineTemps.base);
       }
       if (options.testFW === 'tape') {
-        jsTestString = tempUtils.addTestDataToBaseTemplate(utilData, tapeTemps.base);
+        jsTestString = tempUtils.addTestDataToBaseTemplate(utilData, tapeTemps.base, tapeTemps.plan);
       }
       return jsTestString;
     }

--- a/templates/tape/tape-templates.js
+++ b/templates/tape/tape-templates.js
@@ -2,9 +2,8 @@
 var tempRequire = 'var {{=it.varName}} = require(\'{{=it.module}}\');';
 
 // Base template for tests (deliberately missing ending syntax - closed in util fx)
-var baseTemplate =
-'test(\'{{=it.testTitle}}\', function(t) { \
-t.plan({{=it.assertions}}); \ ';
+var baseTemplate = 'test(\'{{=it.testTitle}}\', function(t) { ';
+var planTemplate = 't.plan({{=it.assertions}});';
 
 // Individual assertion templates
 var equalTemplate = 't.{{=it.assertionType}}({{=it.assertionOutput}}, file.{{=it.assertionInput}}, \'{{=it.assertionMessage}}\');';
@@ -18,6 +17,7 @@ var notOkTemplate = 't.{{=it.assertionType}}(file.{{=it.assertionInput}}, \'{{=i
 module.exports = {
   require: tempRequire,
   base: baseTemplate,
+  plan: planTemplate,
   equal: equalTemplate,
   notEqual: notEqualTemplate,
   deepEqual: deepEqualTemplate,

--- a/templates/template-utils.js
+++ b/templates/template-utils.js
@@ -24,18 +24,20 @@ exports.addRequire = function(varName, module) {
   input:  (String) base-template to build upon with each test and its respective assertions.
   output: (String) interpolated test block.
 */
-exports.addTestDataToBaseTemplate = function(data, baseTemp) {
+exports.addTestDataToBaseTemplate = function(data, baseTemp, planTemp) {
 
   var renderTests = R.reduce(function(testsString, test) {
-    return testsString + renderSingleTest(test, baseTemp) + eol;
+    return testsString + renderSingleTest(test, baseTemp, planTemp) + eol;
   }, '' + eol);
 
-  var renderSingleTest = function(test, baseTemp) {
+  var renderSingleTest = function(test, baseTemp, planTemp) {
     var base = dot.template(baseTemp)({
-      testTitle: test.testTitle,
+      testTitle: test.testTitle
+    });
+    var plan = dot.template(planTemp)({
       assertions: test.assertions.length
     });
-    return base + eol + renderAssertions(test.assertions) + '});';
+    return base + eol + ' ' + ' ' + plan + eol + renderAssertions(test.assertions) + '});';
   };
 
   var renderAssertions = R.reduce(function(assertionsString, assertion) {


### PR DESCRIPTION
Now the `t.plan()` line is on it's own line using `EOL` and indented following the format of the other lines.