### PR TITLE
Now tape tests can be output with no assertions [Closes #69]

### DIFF
--- a/importModuleTest.js
+++ b/importModuleTest.js
@@ -2,15 +2,15 @@ var speck = require('./speck.js');
 var fs = require('fs');
 var path = require('path');
 
-var testString1 = fs.readFileSync(path.join(__dirname, 'src/demo2.js'), {encoding: 'utf8'});
-var testString2 = fs.readFileSync(path.join(__dirname, 'src/demo2.js'), {encoding: 'utf8'});
-var testString3 = fs.readFileSync(path.join(__dirname, 'src/demo2.js'), {encoding: 'utf8'});
+var testString1 = fs.readFileSync(path.join(__dirname, 'src/demo.js'), {encoding: 'utf8'});
+var testString2 = fs.readFileSync(path.join(__dirname, 'src/demo.js'), {encoding: 'utf8'});
+var testString3 = fs.readFileSync(path.join(__dirname, 'src/demo.js'), {encoding: 'utf8'});
 
 var result1 = speck.build({
   name: 'demo.js',
   content: testString1
 }, {
-  testFW: 'jasmine'
+  testFW: 'tape'
 });
 
 var result2 = speck.build({

--- a/speck.js
+++ b/speck.js
@@ -34,20 +34,22 @@ var build = function build(file, options) {
   options = options || defaultOptions;
   var output;
   var tests = comments.parse(file.content).tests;
-
   var testsReadyToAssemble = tests.map(function(test) {
+    var testDetails;
     if (test.assertions.length) {
-      var testDetails = extract.extractTestDetails(test.assertions);
-      var utilData = tempUtils.prepDataForTemplating(options.testFW, file.name, test, testDetails);
-      var jsTestString;
-      if (options.testFW === 'jasmine') {
-        jsTestString = tempUtils.addTestDataToBaseTemplateJasmine(utilData, jasmineTemps.base);
-      }
-      if (options.testFW === 'tape') {
-        jsTestString = tempUtils.addTestDataToBaseTemplate(utilData, tapeTemps.base, tapeTemps.plan);
-      }
-      return jsTestString;
+      testDetails = extract.extractTestDetails(test.assertions);
+    } else {
+      testDetails = '';
     }
+    var utilData = tempUtils.prepDataForTemplating(options.testFW, file.name, test, testDetails);
+    var jsTestString;
+    if (options.testFW === 'jasmine') {
+      jsTestString = tempUtils.addTestDataToBaseTemplateJasmine(utilData, jasmineTemps.base);
+    }
+    if (options.testFW === 'tape') {
+      jsTestString = tempUtils.addTestDataToBaseTemplate(utilData, tapeTemps.base, tapeTemps.plan);
+    }
+    return jsTestString;
   });
 
   output = tempUtils.assembleTestFile(file.name, testsReadyToAssemble, options.testFW);


### PR DESCRIPTION
`testDetails` is now an empty string if there are no assertions and this solves the issue. As you can see by the output below, this causes `t.plan(0)` to show up. I decided to keep this to remind the user to make changes there.

## Output
![image](https://cloud.githubusercontent.com/assets/9373803/9750485/279d4e4c-565e-11e5-94f6-182b2c016727.png)
