### PR TITLE
Remove doT.js from project entirely. [Closes #85]

### DIFF
--- a/importModuleTest.js
+++ b/importModuleTest.js
@@ -17,19 +17,19 @@ var result2 = speck.build({
   name: 'demo.js',
   content: testString2
 }, {
-  testFW: 'tape'
+  testFW: 'jasmine'
 });
 
 console.log('TS1:', result1);
 console.log('TS2:', result2);
 
-speck.build({
-  name: 'demo.js',
-  content: testString3
-}, {
-  testFW: 'tape',
-  onBuild: function(res) {
-    console.log('result callback:');
-    console.log(res);
-  }
-});
+// speck.build({
+//   name: 'demo.js',
+//   content: testString3
+// }, {
+//   testFW: 'jasmine',
+//   onBuild: function(res) {
+//     console.log('result callback:');
+//     console.log(res);
+//   }
+// });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speckjs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "tiny comments, great tests",
   "license": "MIT",
   "contributors": [
@@ -30,7 +30,6 @@
   "dependencies": {
     "extract-values": "^0.1.2",
     "acorn": "^2.3.0",
-    "ramda": "^0.17.1",
-    "dot": "^1.0.3"
+    "ramda": "^0.17.1"
   }
 }

--- a/templates/jasmine/jasmine-templates.js
+++ b/templates/jasmine/jasmine-templates.js
@@ -1,15 +1,43 @@
+var eol = require('os').EOL;
+
+var indent = function(n) {
+  var space = '';
+  for (var i=0 ; i < n; i++) {
+    space += ' ';
+  }
+  return space;
+};
+
 // Utility templates
-var tempRequire = 'var {{=it.varName}} = require(\'{{=it.module}}\');';
-var assertRequire = 'var assert = require(\'assert\');';
+var tempRequire = function(it) {
+  return 'var ' + (it.varName) + ' = require(\'' + (it.module) + '\');';
+};
+
+var assertRequire = function(it) {
+  return 'var assert = require(\'assert\');';
+};
 
 // Base template
-var baseTemplate = 'describe(\'{{=it.testTitle}}\', function() { ';
+var baseTemplate = function(it) {
+  return 'describe(\'' + (it.testTitle) + '\', function() { ';
+};
 
 // Individual assertion templates
-var equalTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}.toBe({{=it.assertionOutput}}))\n});';
-var notEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nexpect(file.{{=it.assertionInput}}.not.toBe({{=it.assertionOutput}}))\n});';
-var deepEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nvar pass;\ntry {\npass = true;\nassert.deepEqual(file.{{=it.assertionInput}}, {{=it.assertionOutput}});\n} catch (e) {\npass = false;\n}\nexpect(pass).toBe(true);\n});\n';
-var notDeepEqualTemplate = 'it(\'{{=it.assertionMessage}}\', function() {\nvar pass;\ntry {\npass = true;\nassert.notDeepEqual(file.{{=it.assertionInput}}, {{=it.assertionOutput}});\n} catch (e) {\npass = false;\n}\nexpect(pass).toBe(true);\n});\n';
+var equalTemplate = function(it) {
+  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.toBe(' + (it.assertionOutput) + '))' + eol + indent(2) + '});';
+};
+
+var notEqualTemplate = function(it) {
+  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.not.toBe(' + (it.assertionOutput) + '))' + eol + indent(2) + '});';
+};
+
+var deepEqualTemplate = function(it) {
+  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + 'try {' + eol + 'pass = true;' + eol + 'assert.deepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + '} catch (e) {' + eol + 'pass = false;' + eol + '}' + eol + 'expect(pass).toBe(true);' + eol + indent(2) + '});' + eol;
+};
+
+var notDeepEqualTemplate = function(it) {
+  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + 'try {' + eol + 'pass = true;' + eol + 'assert.notDeepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + '} catch (e) {' + eol + 'pass = false;' + eol + '}' + eol + 'expect(pass).toBe(true);' + eol + indent(2) + '});' + eol;
+};
 
 module.exports = {
   require: tempRequire,

--- a/templates/tape/tape-templates.js
+++ b/templates/tape/tape-templates.js
@@ -1,19 +1,53 @@
+var eol = require('os').EOL;
+
+/////////////////////
 // Utility templates
-var tempRequire = 'var {{=it.varName}} = require(\'{{=it.module}}\');';
+/////////////////////
+var tempRequire = function(it) {
+  return 'var ' + (it.varName) + ' = require(\'' + (it.module) + '\');' + eol;
+};
 
+////////////////////////////////////////////////////////////////////////////////////
 // Base template for tests (deliberately missing ending syntax - closed in util fx)
-var baseTemplate = 'test(\'{{=it.testTitle}}\', function(t) { ';
-var planTemplate = 't.plan({{=it.assertions}});';
+////////////////////////////////////////////////////////////////////////////////////
+var baseTemplate = function(it) {
+  return 'test(\'' + (it.testTitle) + '\', function(t) { ' + eol;
+};
 
+var planTemplate = function(it) {
+  return 't.plan(' + (it.assertions) + ');' + eol;
+};
+
+//////////////////////////////////
 // Individual assertion templates
-var equalTemplate = 't.{{=it.assertionType}}({{=it.assertionOutput}}, file.{{=it.assertionInput}}, \'{{=it.assertionMessage}}\');';
-var notEqualTemplate = 't.{{=it.assertionType}}({{=it.assertionOutput}}, file.{{=it.assertionInput}}, \'{{=it.assertionMessage}}\');';
-var notDeepEqualTemplate = 't.{{=it.assertionType}}({{=it.assertionOutput}}, file.{{=it.assertionInput}}, \'{{=it.assertionMessage}}\');';
-var deepEqualTemplate = 't.{{=it.assertionType}}({{=it.assertionOutput}}, file.{{=it.assertionInput}}, \'{{=it.assertionMessage}}\');';
-var okTemplate = 't.{{=it.assertionType}}(file.{{=it.assertionInput}}, \'{{=it.assertionMessage}}\');';
-var notOkTemplate = 't.{{=it.assertionType}}(file.{{=it.assertionInput}}, \'{{=it.assertionMessage}}\');';
+//////////////////////////////////
+var equalTemplate = function(it) {
+  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+};
 
+var notEqualTemplate = function(it) {
+  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+};
+
+var notDeepEqualTemplate = function(it) {
+  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+};
+
+var deepEqualTemplate = function(it) {
+  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+};
+
+var okTemplate = function(it) {
+  return 't.' + (it.assertionType) + '(file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+};
+
+var notOkTemplate = function(it) {
+  return 't.' + (it.assertionType) + '(file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+};
+
+////////////////////
 // Export templates
+////////////////////
 module.exports = {
   require: tempRequire,
   base: baseTemplate,

--- a/templates/template-utils.js
+++ b/templates/template-utils.js
@@ -3,6 +3,7 @@ var jasmineTemps = require('./jasmine/jasmine-templates.js');
 var tapeTemps = require('./tape/tape-templates.js');
 var R = require('ramda');
 var eol = require('os').EOL;
+var indent = ' ' + ' ';
 
 /*
   Create require statement from given args.
@@ -11,10 +12,10 @@ var eol = require('os').EOL;
   output: (String) require statement using given arguments.
 */
 exports.addRequire = function(varName, module) {
-  return dot.template(tapeTemps.require)({
+  return tapeTemps.require({
     varName: varName,
     module: module
-  }) + eol;
+  });
 };
 
 
@@ -27,17 +28,17 @@ exports.addRequire = function(varName, module) {
 exports.addTestDataToBaseTemplate = function(data, baseTemp, planTemp) {
 
   var renderTests = R.reduce(function(testsString, test) {
-    return testsString + renderSingleTest(test, baseTemp, planTemp) + eol;
-  }, '' + eol);
+    return testsString + renderSingleTest(test, baseTemp, planTemp);
+  }, '');
 
   var renderSingleTest = function(test, baseTemp, planTemp) {
-    var base = dot.template(baseTemp)({
+    var base = baseTemp({
       testTitle: test.testTitle
     });
-    var plan = dot.template(planTemp)({
+    var plan = planTemp({
       assertions: test.assertions.length
     });
-    return base + eol + ' ' + ' ' + plan + eol + renderAssertions(test.assertions) + '});';
+    return eol + base + indent + plan + renderAssertions(test.assertions) + '});' + eol;
   };
 
   var renderAssertions = R.reduce(function(assertionsString, assertion) {
@@ -46,7 +47,7 @@ exports.addTestDataToBaseTemplate = function(data, baseTemp, planTemp) {
 
   var renderSingleAssertion = function(assertion) {
     var tempToAdd = tapeTemps[assertion.assertionType];
-    return ' ' + ' ' + dot.template(tempToAdd)(assertion) + eol;
+    return indent + tempToAdd(assertion);
   };
 
   return renderTests(data.tests, baseTemp);

--- a/templates/template-utils.js
+++ b/templates/template-utils.js
@@ -1,4 +1,3 @@
-var dot = require('dot');
 var jasmineTemps = require('./jasmine/jasmine-templates.js');
 var tapeTemps = require('./tape/tape-templates.js');
 var R = require('ramda');
@@ -68,7 +67,7 @@ exports.addTestDataToBaseTemplateJasmine = function(data, baseTemp) {
   }, '' + eol);
 
   var renderSingleTest = function(test, baseTemp) {
-    var base = dot.template(baseTemp)({
+    var base = baseTemp({
       testTitle: test.testTitle,
       assertions: test.assertions.length
     });
@@ -81,7 +80,7 @@ exports.addTestDataToBaseTemplateJasmine = function(data, baseTemp) {
 
   var renderSingleAssertion = function(assertion) {
     var tempToAdd = jasmineTemps[assertion.assertionType];
-    return ' ' + ' ' + dot.template(tempToAdd)(assertion) + eol;
+    return tempToAdd(assertion) + eol;
   };
 
   return renderTests(data.tests, baseTemp);


### PR DESCRIPTION
Refactor Tape and Jasmine templates to use our own templating and remove any dependency on doT.js from entire project.

Update `speckjs` version to 0.0.4