### PR TITLE
Feature/validate assertion inputs [Closes #41]

### DIFF
--- a/parsing/comment-conversion.js
+++ b/parsing/comment-conversion.js
@@ -7,10 +7,6 @@ var assertionTypeMap = {
   '!===': 'notDeepEqual'
 };
 
-var test = [
-  'sum(10,10) asdfasdf== 20 (return the sum of both params)'
-];
-
 //Helper takes string as an input, matches to hash map and returns the converted value
 var convertAssertionType = function(type) {
   return assertionTypeMap[type];
@@ -22,21 +18,18 @@ var extractTestDetails = function(parsedAssertions) {
   //Loop over all assertions and use pattern matching to extract the atomic units
   return parsedAssertions.map(function(assertion) {
     assertionParts = extractValues(assertion, '{assertionInput} {assertionType} {assertionOutput} ({assertionMessage})');
-
     //Convert assertion type from symbol to usable syntax
     try {
       assertionParts.assertionType = convertAssertionType(assertionParts.assertionType);
-      if(assertionParts.assertionType === undefined) {
-        throw error();
+      if (assertionParts.assertionType === undefined) {
+        throw 'assertion error';
       }
     } catch(e) {
-      console.error('Error: Invalid assertion type. Must be ==, ===, !== or !===.');
+      assertionParts = {error: 'Assertion syntax error, please fix assertion syntax.'};
     }
     return assertionParts;
   });
 };
-
-console.log(extractTestDetails(test));
 
 module.exports = {
   extractTestDetails: extractTestDetails

--- a/parsing/comment-conversion.js
+++ b/parsing/comment-conversion.js
@@ -7,6 +7,10 @@ var assertionTypeMap = {
   '!===': 'notDeepEqual'
 };
 
+var test = [
+  'sum(10,10) asdfasdf== 20 (return the sum of both params)'
+];
+
 //Helper takes string as an input, matches to hash map and returns the converted value
 var convertAssertionType = function(type) {
   return assertionTypeMap[type];
@@ -20,12 +24,19 @@ var extractTestDetails = function(parsedAssertions) {
     assertionParts = extractValues(assertion, '{assertionInput} {assertionType} {assertionOutput} ({assertionMessage})');
 
     //Convert assertion type from symbol to usable syntax
-    assertionParts.assertionType = convertAssertionType(assertionParts.assertionType);
+    try {
+      assertionParts.assertionType = convertAssertionType(assertionParts.assertionType);
+      if(assertionParts.assertionType === undefined) {
+        throw error();
+      }
+    } catch(e) {
+      console.error('Error: Invalid assertion type. Must be ==, ===, !== or !===.');
+    }
     return assertionParts;
   });
 };
 
-// console.log(extractTestDetails(test));
+console.log(extractTestDetails(test));
 
 module.exports = {
   extractTestDetails: extractTestDetails


### PR DESCRIPTION
Now on the `extractTestDetails` module it checks to see if the atomic units of the SpeckJS syntax are properly formatted. If there is an issue with the formatting, the output is an object like this:
```
{error: 'Assertion syntax error, please fix assertion syntax.'}
```
I did this so later down the pipeline we can print that out to the file so the user sees that but it doesn't break the whole pipeline. This will inform the user and still allow them to write other usable tests.