### PR TITLE
Move extract-values logic into template.utils [Closes #93]

### DIFF
--- a/importModuleTest.js
+++ b/importModuleTest.js
@@ -20,8 +20,8 @@ var result2 = speck.build({
   testFW: 'jasmine'
 });
 
-console.log('TS1:', result1);
-console.log('TS2:', result2);
+console.log(result1);
+console.log(result2);
 
 // speck.build({
 //   name: 'demo.js',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speckjs",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "tiny comments, great tests",
   "license": "MIT",
   "contributors": [
@@ -28,7 +28,6 @@
     "tape": "^4.2.0"
   },
   "dependencies": {
-    "extract-values": "^0.1.2",
     "acorn": "^2.3.0",
     "ramda": "^0.17.1"
   }

--- a/parsing/comment-conversion.js
+++ b/parsing/comment-conversion.js
@@ -1,4 +1,5 @@
-var extractValues = require('extract-values');
+// var extractValues = require('extract-values');
+var extractValues = require('../templates/template-utils.js').extractValues;
 
 var assertionTypeMap = {
   '==': 'equal',

--- a/templates/template-utils.js
+++ b/templates/template-utils.js
@@ -128,3 +128,52 @@ exports.assembleTestFile = function(fileName, tests, framework) {
     return testFile + test;
   }, output, tests);
 };
+
+
+// Taken from npm package 'extract-values', but their method of
+// exporting to 'window' does not work with our Atom package.
+// Per their docs: "This is a simple helper to extract values from a string based on a pattern."
+exports.extractValues = function(str, pattern, options) {
+  options = options || {};
+  var delimiters = options.delimiters || ['{', '}'];
+  var lowercase = options.lowercase;
+  var whitespace = options.whitespace;
+
+  var special_chars_regex = /[\\\^\$\*\+\.\?\(\)]/g;
+  var token_regex = new RegExp(delimiters[0] + '([^' + delimiters.join('') + '\t\r\n]+)' + delimiters[1], 'g');
+  var tokens = pattern.match(token_regex);
+  var pattern_regex = new RegExp(pattern.replace(special_chars_regex, '\\$&').replace(token_regex, '(\.+)'));
+
+  if (lowercase) {
+    str = str.toLowerCase();
+  }
+
+  if (whitespace) {
+    str = str.replace(/\s+/g, function(match) {
+      var whitespace_str = '';
+      for (var i = 0; i < whitespace; i++) {
+        whitespace_str = whitespace_str + match.charAt(0);
+      }
+      return whitespace_str;
+    });
+  }
+
+  var matches = str.match(pattern_regex);
+
+  if (!matches) {
+    return null;
+  }
+
+  // Allow exact string matches to return an empty object instead of null
+  if (!tokens) {
+    return (str === pattern) ? {} : null;
+  }
+
+  matches = matches.splice(1);
+  var output = {};
+  for (var i=0; i < tokens.length; i++) {
+    output[tokens[i].replace(new RegExp(delimiters[0] + '|' + delimiters[1], 'g'), '')] = matches[i];
+  }
+
+  return output;
+};


### PR DESCRIPTION
* Moved logic from extract-values module into template-utils so that it would be usable in other systems (namely Atom).
* Completely remove original extract-values module from project.
* Update `speckjs` version to 0.0.5.