### PR TITLE
Fixed formatting issues with try/catch blocks [Closes #81]

### DIFF
--- a/templates/jasmine/jasmine-templates.js
+++ b/templates/jasmine/jasmine-templates.js
@@ -24,11 +24,11 @@ var baseTemplate = function(it) {
 
 // Individual assertion templates
 var equalTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.toBe(' + (it.assertionOutput) + '))' + eol + indent(2) + '});';
+  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.toBe(' + (it.assertionOutput) + '));' + eol + indent(2) + '});';
 };
 
 var notEqualTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.not.toBe(' + (it.assertionOutput) + '))' + eol + indent(2) + '});';
+  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.not.toBe(' + (it.assertionOutput) + '));' + eol + indent(2) + '});';
 };
 
 var deepEqualTemplate = function(it) {

--- a/templates/jasmine/jasmine-templates.js
+++ b/templates/jasmine/jasmine-templates.js
@@ -32,11 +32,11 @@ var notEqualTemplate = function(it) {
 };
 
 var deepEqualTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + 'try {' + eol + 'pass = true;' + eol + 'assert.deepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + '} catch (e) {' + eol + 'pass = false;' + eol + '}' + eol + 'expect(pass).toBe(true);' + eol + indent(2) + '});' + eol;
+  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + indent(4) +'try {' + eol + indent(6) + 'pass = true;' + eol + indent(6) + 'assert.deepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + indent(4) + '} catch (e) {' + eol + indent(6) + 'pass = false;' + eol + indent(4) + '}' + eol + indent(4) + 'expect(pass).toBe(true);' + eol + indent(2) + '});' + eol;
 };
 
 var notDeepEqualTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + 'try {' + eol + 'pass = true;' + eol + 'assert.notDeepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + '} catch (e) {' + eol + 'pass = false;' + eol + '}' + eol + 'expect(pass).toBe(true);' + eol + indent(2) + '});' + eol;
+  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + indent(4) +'try {' + eol + indent(6) + 'pass = true;' + eol + indent(6) + 'assert.notDeepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + indent(4) + '} catch (e) {' + eol + indent(6) + 'pass = false;' + eol + indent(4) +'}' + eol + indent(4) + 'expect(pass).toBe(true);' + eol + indent(2) + '});' + eol;
 };
 
 module.exports = {

--- a/templates/template-utils.js
+++ b/templates/template-utils.js
@@ -120,7 +120,7 @@ exports.assembleTestFile = function(fileName, tests, framework) {
   // Write require statements for testing library and parsed file
   var output = '';
   if (framework === 'jasmine') {
-    output += jasmineTemps.assert + eol;
+    output += jasmineTemps.assert() + eol;
   }
   output += exports.addRequire('test', framework) + exports.addRequire('file', fileName);
 


### PR DESCRIPTION
Fixed the indentation of the `try{}catch(){}` blocks for the deepEqual/notDeepEqual assertions in the Jasmine test output.

Closes #90  - `require('assert')` is fixed and added a missing semicolon on the expect statements.