### PR TITLE
Allow Custom RegEx patterns for test comments

### DIFF
--- a/src/parsing/parse-comments.js
+++ b/src/parsing/parse-comments.js
@@ -27,12 +27,14 @@ var acorn = require('acorn/dist/acorn_csp.js');
 var acornOptions = {locations: true, onComment: onComment};
 var tests = [];
 
+var tRegex;
+var aRegex;
 
 // Sanitizing iterator to run on each comment found during parsing
 function onComment(isBlock, text, _s, _e, sLoc, eLoc) {
 
-  var tRegex = /test\s*>\s*(.*)/i;
-  var aRegex = /#\s*(.*)/i;
+  
+  
   var isTest = R.test(tRegex);
   var extractTest = R.pipe(R.match(tRegex), R.last(), R.trim());
   var isAssertion = R.test(aRegex);
@@ -96,8 +98,17 @@ var parse = function(string, options) {
   return output;
 };
 
+// 
+// # setRegex - Allows us to overwrite the default regex to pick tests from comments
+// 
+var setRegex = function(titleRegex, assertionRegex) {
+    tRegex = titleRegex;
+    aRegex =  assertionRegex;
+}
+
 
 // Public parsing API
 module.exports = {
-  parse: parse
+  parse: parse,
+  setRegex: setRegex
 };

--- a/src/speck.js
+++ b/src/speck.js
@@ -10,7 +10,9 @@ var R = require('ramda');
 //Default options for build function
 var defaultOptions = {
   testFW: 'tape',
-  onBuild: null
+  onBuild: null,
+  tRegex: /test\s*>\s*(.*)/i,
+  aRegex: /#\s*(.*)/i
 };
 
 //Takes a file object with SpeckJS-formatted comments as input. Returns a string
@@ -18,6 +20,7 @@ var defaultOptions = {
 var build = function build(file, options) {
   options = options ? R.merge(defaultOptions, options) : defaultOptions;
   var output;
+  comments.setRegex(options.tRegex, options.aRegex);
   var tests = comments.parse(file.content).tests;
   var testsReadyToAssemble = tests.map(function(test) {
     var testDetails;


### PR DESCRIPTION
For our project we wanted to have test comments in the following format:
```javascript
// 
// # Create JSON per instance
//      > create_json_per_instance("a","b") == "c" (returns c because...)
// 
```
Instead of keeping a forked version of Spec.js I thought it would be useful to allow custom Regular expression patterns to be provided as options.
Tested it through grunt-speckjs with the following options:
```javascript
speck: {
          options: {
            specType: 'jasmine',
            testFW:'jasmine',
            specName: '--commentSpec',
            logs: true,
            tRegex: /\s*#+\s*(.*)/i,
            aRegex: />\s*(.*)/i
          },
          target: {
            src: ['bin/**/*.js'],
            dest: 'test/specs/'
          },
        },
```