### PR TITLE
Bug/acorn csp missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tape": "^4.2.0"
   },
   "dependencies": {
-    "acorn": "^2.3.0",
+    "acorn": "2.3.0",
     "ramda": "^0.17.1"
   }
 }

--- a/test/fixtures/base.js
+++ b/test/fixtures/base.js
@@ -8,7 +8,7 @@ module.exports = {
     return a - b;
   },
 
-  // test > product function
+  // test > quotient function
   // # quotient(6,3) == 2 (returns the quotient of both params)
   // # quotient(10,10) !== 9 (returns the quotient of both params)
   // # quotient(25,5) !=== 10 (returns the quotient of both params)

--- a/test/importModuleTest.js
+++ b/test/importModuleTest.js
@@ -24,7 +24,10 @@ var result3 = speck.build({
   name: 'base.js',
   content: testString3
 }, {
-  testFW: 'tape'
+  testFW: 'tape',
+  onBuild: function(data) {
+    console.log('Applying a callback:\n', data);
+  }
 });
 
 console.log(result1);


### PR DESCRIPTION
`package.json` now requires the version of Acorn that was used throughout the main production of SpeckJS. This build still includes `dist/acorn_csp.js`, and I've opted to use this version as opposed to changing SpeckJS to use Acorn's current `dist/acorn.js` because it appears there is still conversation amongst their contributors regarding this new implementation.

Below are snapshots from Acorn's repo where these changes took place (releases 2.5.0 - 2.6.0).
[Source](https://github.com/ternjs/acorn/commit/aed55f3881beb1ea26d8622ada9973839b2b7175)

![screen shot 2015-11-11 at 9 37 23 pm](https://cloud.githubusercontent.com/assets/3118710/11125884/2aea26ce-8921-11e5-910f-84b993d07601.png)

![screen shot 2015-11-11 at 9 45 09 pm](https://cloud.githubusercontent.com/assets/3118710/11125885/306a88aa-8921-11e5-9e2c-d23e3d018291.png)