### PR TITLE
Refactor/cleanup main and helper file

### DIFF
--- a/src/parsing/comment-conversion.js
+++ b/src/parsing/comment-conversion.js
@@ -1,5 +1,3 @@
-var extractValues = require('../templates/template-utils.js').extractValues;
-
 var assertionTypeMap = {
   '==': 'equal',
   '===': 'deepEqual',
@@ -15,7 +13,7 @@ var convertAssertionType = function(type) {
 var extractTestDetails = function(parsedAssertions) {
   var assertionParts;
   return parsedAssertions.map(function(assertion) {
-    assertionParts = extractValues(assertion, '{assertionInput} {assertionType} {assertionOutput} ({assertionMessage})');
+    assertionParts = _extractValues(assertion, '{assertionInput} {assertionType} {assertionOutput} ({assertionMessage})');
     try {
       assertionParts.assertionType = convertAssertionType(assertionParts.assertionType);
       if (assertionParts.assertionType === undefined) {
@@ -26,6 +24,54 @@ var extractTestDetails = function(parsedAssertions) {
     }
     return assertionParts;
   });
+};
+
+// Taken from npm package 'extract-values', but their method of
+// exporting to 'window' does not work with our Atom package.
+// Per their docs: "This is a simple helper to extract values from a string based on a pattern."
+var _extractValues = function(str, pattern, options) {
+  options = options || {};
+  var delimiters = options.delimiters || ['{', '}'];
+  var lowercase = options.lowercase;
+  var whitespace = options.whitespace;
+
+  var special_chars_regex = /[\\\^\$\*\+\.\?\(\)]/g;
+  var token_regex = new RegExp(delimiters[0] + '([^' + delimiters.join('') + '\t\r\n]+)' + delimiters[1], 'g');
+  var tokens = pattern.match(token_regex);
+  var pattern_regex = new RegExp(pattern.replace(special_chars_regex, '\\$&').replace(token_regex, '(\.+)'));
+
+  if (lowercase) {
+    str = str.toLowerCase();
+  }
+
+  if (whitespace) {
+    str = str.replace(/\s+/g, function(match) {
+      var whitespace_str = '';
+      for (var i = 0; i < whitespace; i++) {
+        whitespace_str = whitespace_str + match.charAt(0);
+      }
+      return whitespace_str;
+    });
+  }
+
+  var matches = str.match(pattern_regex);
+
+  if (!matches) {
+    return null;
+  }
+
+  // Allow exact string matches to return an empty object instead of null
+  if (!tokens) {
+    return (str === pattern) ? {} : null;
+  }
+
+  matches = matches.splice(1);
+  var output = {};
+  for (var i=0; i < tokens.length; i++) {
+    output[tokens[i].replace(new RegExp(delimiters[0] + '|' + delimiters[1], 'g'), '')] = matches[i];
+  }
+
+  return output;
 };
 
 module.exports = {

--- a/src/parsing/parse-comments.js
+++ b/src/parsing/parse-comments.js
@@ -5,7 +5,7 @@
   Speckjs formatted comment example:
   ```
   // test > sum function
-  // # sum(1,3) == 4 (returnt.equal(4, file.sum(13) the sum of both params)
+  // # sum(1,3) == 4 (returns the sum of both params)
   // # sum(10,10) == 20 (return the sum of both params)
   ```
   Return an array of raw test objects in the form of:
@@ -15,8 +15,8 @@
       title: 'sum function',
       loc: { startLine: 0, endLine: 10},`
       assertions: [
-        'sum(1,3) == 4 (return the sum of both params)',
-        'sum(10,10) == 20 (return the sum of both params)'
+        'sum(1,3) == 4 (returns the sum of both params)',
+        'sum(10,10) == 20 (returns the sum of both params)'
       ]
     }
   ]

--- a/src/speck.js
+++ b/src/speck.js
@@ -7,18 +7,20 @@ var mochaChaiTemps = require('./templates/mocha-chai/mocha-chai-templates.js');
 var tempUtils = require('./templates/template-utils.js');
 var R = require('ramda');
 
-//Default options for build function
+// Default options for build function
 var defaultOptions = {
   testFW: 'tape',
   onBuild: null
 };
 
-//Takes a file object with SpeckJS-formatted comments as input. Returns a string
-//representation of a spec file and optionally invokes a callback on that string
+// Accepts a file object with SpeckJS-formatted comments as input
+// Returns a string representation of a spec file, or
+// Invokes optional callback on that string if provided in arguments
 var build = function build(file, options) {
   options = options ? R.merge(defaultOptions, options) : defaultOptions;
   var output;
   var tests = comments.parse(file.content).tests;
+
   var testsReadyToAssemble = tests.map(function(test) {
     var testDetails;
     if (test.assertions.length) {
@@ -26,17 +28,20 @@ var build = function build(file, options) {
     } else {
       testDetails = '';
     }
+
     var utilData = tempUtils.prepDataForTemplating(options.testFW, file.name, test, testDetails);
     var jsTestString;
+
     if (options.testFW === 'jasmine') {
       jsTestString = tempUtils.addTestDataToBaseTemplateJasmine(utilData, jasmineTemps.base);
     }
     if (options.testFW === 'tape') {
       jsTestString = tempUtils.addTestDataToBaseTemplate(utilData, tapeTemps.base, tapeTemps.plan);
     }
-     if (options.testFW === 'mocha-chai') {
+    if (options.testFW === 'mocha-chai') {
       jsTestString = tempUtils.addTestDataToBaseTemplateMochaChai(utilData, mochaChaiTemps.base);
     }
+
     return jsTestString;
   });
 

--- a/src/speck.js
+++ b/src/speck.js
@@ -1,9 +1,5 @@
 // Dependencies
 var comments = require('./parsing/parse-comments.js');
-var extract = require('./parsing/comment-conversion.js');
-var tapeTemps = require('./templates/tape/tape-templates.js');
-var jasmineTemps = require('./templates/jasmine/jasmine-templates.js');
-var mochaChaiTemps = require('./templates/mocha-chai/mocha-chai-templates.js');
 var tempUtils = require('./templates/template-utils.js');
 var R = require('ramda');
 
@@ -18,23 +14,9 @@ var defaultOptions = {
 // Invokes optional callback on that string if provided in arguments
 var build = function build(file, options) {
   options = options ? R.merge(defaultOptions, options) : defaultOptions;
-  var output;
   var tests = comments.parse(file.content).tests;
-
-  var testsReadyToAssemble = tests.map(function(test) {
-    var testDetails;
-    if (test.assertions.length) {
-      testDetails = extract.extractTestDetails(test.assertions);
-    } else {
-      testDetails = '';
-    }
-
-    var utilData = tempUtils.prepDataForTemplating(options.testFW, file.name, test, testDetails);
-
-    return tempUtils.addTestDataToTemplate(utilData, options.testFW);
-  });
-
-  output = tempUtils.assembleTestFile(file.name, testsReadyToAssemble, options.testFW);
+  var testsReadyForAssembly = tempUtils.prepareTestsForAssembly(tests, file, options);
+  var output = tempUtils.assembleTestFile(file.name, testsReadyForAssembly, options.testFW);
 
   if (typeof options.onBuild === 'function') {
     options.onBuild(output);

--- a/src/speck.js
+++ b/src/speck.js
@@ -36,7 +36,7 @@ var build = function build(file, options) {
       jsTestString = tempUtils.addTestDataToBaseTemplateJasmine(utilData, jasmineTemps.base);
     }
     if (options.testFW === 'tape') {
-      jsTestString = tempUtils.addTestDataToBaseTemplate(utilData, tapeTemps.base, tapeTemps.plan);
+      jsTestString = tempUtils.addTestDataToBaseTemplateTape(utilData, tapeTemps.base, tapeTemps.plan);
     }
     if (options.testFW === 'mocha-chai') {
       jsTestString = tempUtils.addTestDataToBaseTemplateMochaChai(utilData, mochaChaiTemps.base);

--- a/src/speck.js
+++ b/src/speck.js
@@ -30,19 +30,8 @@ var build = function build(file, options) {
     }
 
     var utilData = tempUtils.prepDataForTemplating(options.testFW, file.name, test, testDetails);
-    var jsTestString;
 
-    if (options.testFW === 'jasmine') {
-      jsTestString = tempUtils.addTestDataToBaseTemplateJasmine(utilData, jasmineTemps.base);
-    }
-    if (options.testFW === 'tape') {
-      jsTestString = tempUtils.addTestDataToBaseTemplateTape(utilData, tapeTemps.base, tapeTemps.plan);
-    }
-    if (options.testFW === 'mocha-chai') {
-      jsTestString = tempUtils.addTestDataToBaseTemplateMochaChai(utilData, mochaChaiTemps.base);
-    }
-
-    return jsTestString;
+    return tempUtils.addTestDataToBaseTemplate(utilData, options.testFW);
   });
 
   output = tempUtils.assembleTestFile(file.name, testsReadyToAssemble, options.testFW);

--- a/src/speck.js
+++ b/src/speck.js
@@ -31,7 +31,7 @@ var build = function build(file, options) {
 
     var utilData = tempUtils.prepDataForTemplating(options.testFW, file.name, test, testDetails);
 
-    return tempUtils.addTestDataToBaseTemplate(utilData, options.testFW);
+    return tempUtils.addTestDataToTemplate(utilData, options.testFW);
   });
 
   output = tempUtils.assembleTestFile(file.name, testsReadyToAssemble, options.testFW);

--- a/src/templates/jasmine/jasmine-templates.js
+++ b/src/templates/jasmine/jasmine-templates.js
@@ -24,19 +24,19 @@ var baseTemplate = function(it) {
 
 // Individual assertion templates
 var equalTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.toBe(' + (it.assertionOutput) + '));' + eol + indent(2) + '});';
+  return 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.toBe(' + (it.assertionOutput) + '));' + eol + indent(2) + '});';
 };
 
 var notEqualTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.not.toBe(' + (it.assertionOutput) + '));' + eol + indent(2) + '});';
+  return 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'expect(file.' + (it.assertionInput) + '.not.toBe(' + (it.assertionOutput) + '));' + eol + indent(2) + '});';
 };
 
 var deepEqualTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + indent(4) +'try {' + eol + indent(6) + 'pass = true;' + eol + indent(6) + 'assert.deepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + indent(4) + '} catch (e) {' + eol + indent(6) + 'pass = false;' + eol + indent(4) + '}' + eol + indent(4) + 'expect(pass).toBe(true);' + eol + indent(2) + '});' + eol;
+  return 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + indent(4) +'try {' + eol + indent(6) + 'pass = true;' + eol + indent(6) + 'assert.deepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + indent(4) + '} catch (e) {' + eol + indent(6) + 'pass = false;' + eol + indent(4) + '}' + eol + indent(4) + 'expect(pass).toBe(true);' + eol + indent(2) + '});';
 };
 
 var notDeepEqualTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + indent(4) +'try {' + eol + indent(6) + 'pass = true;' + eol + indent(6) + 'assert.notDeepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + indent(4) + '} catch (e) {' + eol + indent(6) + 'pass = false;' + eol + indent(4) +'}' + eol + indent(4) + 'expect(pass).toBe(true);' + eol + indent(2) + '});' + eol;
+  return 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'var pass;' + eol + indent(4) +'try {' + eol + indent(6) + 'pass = true;' + eol + indent(6) + 'assert.notDeepEqual(file.' + (it.assertionInput) + ', ' + (it.assertionOutput) + ');' + eol + indent(4) + '} catch (e) {' + eol + indent(6) + 'pass = false;' + eol + indent(4) +'}' + eol + indent(4) + 'expect(pass).toBe(true);' + eol + indent(2) + '});';
 };
 
 module.exports = {

--- a/src/templates/mocha-chai/mocha-chai-templates.js
+++ b/src/templates/mocha-chai/mocha-chai-templates.js
@@ -25,19 +25,19 @@ var baseTemplate = function(it) {
 
 // Individual assertion templates
 var equalTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'file.' + (it.assertionInput) + '.should.equal(' + (it.assertionOutput) + ');' + eol + indent(2) + '});';
+  return 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'file.' + (it.assertionInput) + '.should.equal(' + (it.assertionOutput) + ');' + eol + indent(2) + '});';
 };
 
 var notEqualTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'file.' + (it.assertionInput) + '.should.not.equal(' + (it.assertionOutput) + ');' + eol + indent(2) + '});';
+  return 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'file.' + (it.assertionInput) + '.should.not.equal(' + (it.assertionOutput) + ');' + eol + indent(2) + '});';
 };
 
 var deepEqualTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'file.' + (it.assertionInput) + '.should.deep.equal(' + (it.assertionOutput) + ');' + eol + indent(2) + '});';
+  return 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'file.' + (it.assertionInput) + '.should.deep.equal(' + (it.assertionOutput) + ');' + eol + indent(2) + '});';
 };
 
 var notDeepEqualTemplate = function(it) {
-  return indent(2) + 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'file.' + (it.assertionInput) + '.should.not.deep.equal(' + (it.assertionOutput) + ');' + eol + indent(2) + '});';
+  return 'it(\'' + (it.assertionMessage) + '\', function() {' + eol + indent(4) + 'file.' + (it.assertionInput) + '.should.not.deep.equal(' + (it.assertionOutput) + ');' + eol + indent(2) + '});';
 };
 
 module.exports = {

--- a/src/templates/tape/tape-templates.js
+++ b/src/templates/tape/tape-templates.js
@@ -16,27 +16,27 @@ var planTemplate = function(it) {
 
 //Individual Assertion templates
 var equalTemplate = function(it) {
-  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');';
 };
 
 var notEqualTemplate = function(it) {
-  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');';
 };
 
 var notDeepEqualTemplate = function(it) {
-  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');';
 };
 
 var deepEqualTemplate = function(it) {
-  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+  return 't.' + (it.assertionType) + '(' + (it.assertionOutput) + ', file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');';
 };
 
 var okTemplate = function(it) {
-  return 't.' + (it.assertionType) + '(file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+  return 't.' + (it.assertionType) + '(file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');';
 };
 
 var notOkTemplate = function(it) {
-  return 't.' + (it.assertionType) + '(file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');' + eol;
+  return 't.' + (it.assertionType) + '(file.' + (it.assertionInput) + ', \'' + (it.assertionMessage) + '\');';
 };
 
 module.exports = {

--- a/src/templates/template-utils.js
+++ b/src/templates/template-utils.js
@@ -21,89 +21,21 @@ exports.addTestDataToBaseTemplateTape = function(data, baseTemp, planTemp) {
     return testsString + _renderSingleTapeTest(test, baseTemp, planTemp);
   }, '');
 
-  // var renderSingleTapeTest = function(test, baseTemp, planTemp) {
-  //   var base = baseTemp({
-  //     testTitle: test.testTitle
-  //   });
-  //   var plan = planTemp({
-  //     assertions: test.assertions.length
-  //   });
-  //   return eol + base + indent + plan + _renderAssertions(test.assertions) + '});' + eol;
-  // };
-
-  // var renderAssertions = R.reduce(function(assertionsString, assertion) {
-  //   return assertionsString + renderSingleAssertion(assertion);
-  // }, '');
-
-  // var renderSingleAssertion = function(assertion) {
-  //   var tempToAdd = tapeTemps[assertion.assertionType];
-  //   if (!tempToAdd) {
-  //     return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
-  //   }
-  //   return indent + tempToAdd(assertion);
-  // };
-
   return _renderTapeTests(data.tests, baseTemp);
 };
 
 
 // Transforms data into Jasmine specs. Input -> test data, template
 exports.addTestDataToBaseTemplateJasmine = function(data, baseTemp) {
-  var renderTests = R.reduce(function(testsString, test) {
-    return testsString + _renderSingleTest(test, baseTemp) + eol;
-  }, '' + eol);
-
-  // var renderSingleTest = function(test, baseTemp) {
-  //   var base = baseTemp({
-  //     testTitle: test.testTitle,
-  //     assertions: test.assertions.length
-  //   });
-  //   return base + eol + renderAssertions(test.assertions) + '});';
-  // };
-
-  // var renderAssertions = R.reduce(function(assertionsString, assertion) {
-  //   return assertionsString + renderSingleAssertion(assertion);
-  // }, '');
-
-  // var renderSingleAssertion = function(assertion) {
-  //   var tempToAdd = jasmineTemps[assertion.assertionType];
-  //   if (!tempToAdd) {
-  //     return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
-  //   }
-  //   return tempToAdd(assertion) + eol;
-  // };
-
-  return renderTests(data.tests, baseTemp);
+  _renderTests.fw = "jasmine";
+  return _renderTests(data.tests, baseTemp);
 };
 
 
 // Transforms data into Mocha/Chai specs. Input -> test data, template
 exports.addTestDataToBaseTemplateMochaChai = function(data, baseTemp) {
-  var renderTests = R.reduce(function(testsString, test) {
-    return testsString + _renderSingleTest(test, baseTemp) + eol;
-  }, '' + eol);
-
-  // var renderSingleTest = function(test, baseTemp) {
-  //   var base = baseTemp({
-  //     testTitle: test.testTitle,
-  //     assertions: test.assertions.length
-  //   });
-  //   return base + eol + renderAssertions(test.assertions) + '});';
-  // };
-
-  // var renderAssertions = R.reduce(function(assertionsString, assertion) {
-  //   return assertionsString + renderSingleAssertion(assertion);
-  // }, '');
-
-  // var renderSingleAssertion = function(assertion) {
-  //   var tempToAdd = mochaChaiTemps[assertion.assertionType];
-  //   if (!tempToAdd) {
-  //     return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
-  //   }
-  //   return tempToAdd(assertion) + eol;
-  // };
-
-  return renderTests(data.tests, baseTemp);
+  _renderTests.fw = "mocha-chai";
+  return _renderTests(data.tests, baseTemp);
 };
 
 
@@ -209,6 +141,7 @@ var _renderSingleAssertion = function(assertion) {
 ////////////
 // for Tape
 ////////////
+// Tape's use of 'plan' requires slightly different template building
 var _renderTapeTests = R.reduce(function(testsString, test) {
   return testsString + _renderSingleTapeTest(test, tapeTemps.base, tapeTemps.plan);
 }, '');
@@ -224,8 +157,13 @@ var _renderSingleTapeTest = function(test, baseTemp, planTemp) {
 };
 
 /////////////////////////////
-// for Jasmine or Mocha-Chai
+// for Jasmine and Mocha-Chai
 /////////////////////////////
+var _renderTests = R.reduce(function(testsString, test) {
+  var baseTemp = _renderTests.fw === 'jasmine' ? jasmineTemps.base : mochaChaiTemps.base;
+  return testsString + _renderSingleTest(test, baseTemp) + eol;
+}, '' + eol);
+
 var _renderSingleTest = function(test, baseTemp) {
   var base = baseTemp({
     testTitle: test.testTitle,
@@ -233,5 +171,3 @@ var _renderSingleTest = function(test, baseTemp) {
   });
   return base + eol + _renderAssertions(test.assertions) + '});';
 };
-
-

--- a/src/templates/template-utils.js
+++ b/src/templates/template-utils.js
@@ -6,7 +6,7 @@ var R = require('ramda');
 var eol = require('os').EOL;
 var indent = ' ' + ' ';
 
-// Takes data and creates a properly formatted object to use in template functions
+// Takes data and creates a properly formatted object for use in template functions
 exports.prepDataForTemplating = function(testFW, fileName, currentTest, testDetails) {
   return {
     specType : testFW,
@@ -38,6 +38,7 @@ exports.prepareTestsForAssembly = function(tests, file, options) {
 exports.assembleTestFile = function(fileName, tests, framework) {
   var output = '';
 
+  // Adds necessary require statements
   if (framework === 'jasmine') {
     output += jasmineTemps.assert() + eol;
   }
@@ -48,9 +49,9 @@ exports.assembleTestFile = function(fileName, tests, framework) {
   if(framework === 'tape') {
     output += exports.addRequire('test', framework);
   }
-
   output += exports.addRequire('file', fileName);
 
+  // Adds each test to the file, then returns file
   return R.reduce(function(testFile, test) {
     return testFile + test;
   }, output, tests);
@@ -87,9 +88,9 @@ var _addTestDataToTemplate = function(data, fw) {
   return _renderTests(data.tests);
 };
 
-////////////////
-// render tests
-////////////////
+/////////////////////////////////////////////////////////////
+// render tests * NOTE: a test is comprised of 1+ assertions
+/////////////////////////////////////////////////////////////
 var _renderTests = R.reduce(function(testsString, test) {
   var currentType = _getCurrentSpecType();
   if (currentType === 'tape') {
@@ -130,7 +131,7 @@ var _renderSingleAssertion = function(assertion) {
     return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
   }
 
-  return indent + tempToAdd(assertion);
+  return indent + tempToAdd(assertion) + eol;
 };
 
 ////////////

--- a/src/templates/template-utils.js
+++ b/src/templates/template-utils.js
@@ -5,7 +5,8 @@ var R = require('ramda');
 var eol = require('os').EOL;
 var indent = ' ' + ' ';
 
-//Create require statement for test files
+// Create require statement for test files
+// * tapeTemps require statement also valid for Jasmine/Mocha-Chai *
 exports.addRequire = function(varName, module) {
   return tapeTemps.require({
     varName: varName,
@@ -14,92 +15,93 @@ exports.addRequire = function(varName, module) {
 };
 
 
-//Transforms object into JS tape test code.  Input is test data and templates
-exports.addTestDataToBaseTemplate = function(data, baseTemp, planTemp) {
-
-  var renderTests = R.reduce(function(testsString, test) {
-    return testsString + renderSingleTest(test, baseTemp, planTemp);
+// Transforms data into Tape specs. Input -> test data, templates
+exports.addTestDataToBaseTemplateTape = function(data, baseTemp, planTemp) {
+  var renderTapeTests = R.reduce(function(testsString, test) {
+    return testsString + _renderSingleTapeTest(test, baseTemp, planTemp);
   }, '');
 
-  var renderSingleTest = function(test, baseTemp, planTemp) {
-    var base = baseTemp({
-      testTitle: test.testTitle
-    });
-    var plan = planTemp({
-      assertions: test.assertions.length
-    });
-    return eol + base + indent + plan + renderAssertions(test.assertions) + '});' + eol;
-  };
+  // var renderSingleTapeTest = function(test, baseTemp, planTemp) {
+  //   var base = baseTemp({
+  //     testTitle: test.testTitle
+  //   });
+  //   var plan = planTemp({
+  //     assertions: test.assertions.length
+  //   });
+  //   return eol + base + indent + plan + _renderAssertions(test.assertions) + '});' + eol;
+  // };
 
-  var renderAssertions = R.reduce(function(assertionsString, assertion) {
-    return assertionsString + renderSingleAssertion(assertion);
-  }, '');
+  // var renderAssertions = R.reduce(function(assertionsString, assertion) {
+  //   return assertionsString + renderSingleAssertion(assertion);
+  // }, '');
 
-  var renderSingleAssertion = function(assertion) {
-    var tempToAdd = tapeTemps[assertion.assertionType];
-    if (!tempToAdd) {
-      return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
-    }
-    return indent + tempToAdd(assertion);
-  };
+  // var renderSingleAssertion = function(assertion) {
+  //   var tempToAdd = tapeTemps[assertion.assertionType];
+  //   if (!tempToAdd) {
+  //     return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
+  //   }
+  //   return indent + tempToAdd(assertion);
+  // };
 
-  return renderTests(data.tests, baseTemp);
+  return _renderTapeTests(data.tests, baseTemp);
 };
 
-//Transforms object into JS jasmine test code.  Input -> test data, template
+
+// Transforms data into Jasmine specs. Input -> test data, template
 exports.addTestDataToBaseTemplateJasmine = function(data, baseTemp) {
   var renderTests = R.reduce(function(testsString, test) {
-    return testsString + renderSingleTest(test, baseTemp) + eol;
+    return testsString + _renderSingleTest(test, baseTemp) + eol;
   }, '' + eol);
 
-  var renderSingleTest = function(test, baseTemp) {
-    var base = baseTemp({
-      testTitle: test.testTitle,
-      assertions: test.assertions.length
-    });
-    return base + eol + renderAssertions(test.assertions) + '});';
-  };
+  // var renderSingleTest = function(test, baseTemp) {
+  //   var base = baseTemp({
+  //     testTitle: test.testTitle,
+  //     assertions: test.assertions.length
+  //   });
+  //   return base + eol + renderAssertions(test.assertions) + '});';
+  // };
 
-  var renderAssertions = R.reduce(function(assertionsString, assertion) {
-    return assertionsString + renderSingleAssertion(assertion);
-  }, '');
+  // var renderAssertions = R.reduce(function(assertionsString, assertion) {
+  //   return assertionsString + renderSingleAssertion(assertion);
+  // }, '');
 
-  var renderSingleAssertion = function(assertion) {
-    var tempToAdd = jasmineTemps[assertion.assertionType];
-    if (!tempToAdd) {
-      return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
-    }
-    return tempToAdd(assertion) + eol;
-  };
+  // var renderSingleAssertion = function(assertion) {
+  //   var tempToAdd = jasmineTemps[assertion.assertionType];
+  //   if (!tempToAdd) {
+  //     return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
+  //   }
+  //   return tempToAdd(assertion) + eol;
+  // };
 
   return renderTests(data.tests, baseTemp);
 };
 
-//Transforms object into JS mocha chai test code.  Input -> test data, template
+
+// Transforms data into Mocha/Chai specs. Input -> test data, template
 exports.addTestDataToBaseTemplateMochaChai = function(data, baseTemp) {
   var renderTests = R.reduce(function(testsString, test) {
-    return testsString + renderSingleTest(test, baseTemp) + eol;
+    return testsString + _renderSingleTest(test, baseTemp) + eol;
   }, '' + eol);
 
-  var renderSingleTest = function(test, baseTemp) {
-    var base = baseTemp({
-      testTitle: test.testTitle,
-      assertions: test.assertions.length
-    });
-    return base + eol + renderAssertions(test.assertions) + '});';
-  };
+  // var renderSingleTest = function(test, baseTemp) {
+  //   var base = baseTemp({
+  //     testTitle: test.testTitle,
+  //     assertions: test.assertions.length
+  //   });
+  //   return base + eol + renderAssertions(test.assertions) + '});';
+  // };
 
-  var renderAssertions = R.reduce(function(assertionsString, assertion) {
-    return assertionsString + renderSingleAssertion(assertion);
-  }, '');
+  // var renderAssertions = R.reduce(function(assertionsString, assertion) {
+  //   return assertionsString + renderSingleAssertion(assertion);
+  // }, '');
 
-  var renderSingleAssertion = function(assertion) {
-    var tempToAdd = mochaChaiTemps[assertion.assertionType];
-    if (!tempToAdd) {
-      return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
-    }
-    return tempToAdd(assertion) + eol;
-  };
+  // var renderSingleAssertion = function(assertion) {
+  //   var tempToAdd = mochaChaiTemps[assertion.assertionType];
+  //   if (!tempToAdd) {
+  //     return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
+  //   }
+  //   return tempToAdd(assertion) + eol;
+  // };
 
   return renderTests(data.tests, baseTemp);
 };
@@ -187,3 +189,49 @@ exports.extractValues = function(str, pattern, options) {
 
   return output;
 };
+
+
+///////////////////
+// PRIVATE HELPERS
+///////////////////
+var _renderAssertions = R.reduce(function(assertionsString, assertion) {
+  return assertionsString + _renderSingleAssertion(assertion);
+}, '');
+
+var _renderSingleAssertion = function(assertion) {
+  var tempToAdd = tapeTemps[assertion.assertionType];
+  if (!tempToAdd) {
+    return indent + 'ERROR: PLEASE CHECK YOUR ASSERTION SYNTAX' + eol;
+  }
+  return indent + tempToAdd(assertion);
+};
+
+////////////
+// for Tape
+////////////
+var _renderTapeTests = R.reduce(function(testsString, test) {
+  return testsString + _renderSingleTapeTest(test, tapeTemps.base, tapeTemps.plan);
+}, '');
+
+var _renderSingleTapeTest = function(test, baseTemp, planTemp) {
+  var base = baseTemp({
+    testTitle: test.testTitle
+  });
+  var plan = planTemp({
+    assertions: test.assertions.length
+  });
+  return eol + base + indent + plan + _renderAssertions(test.assertions) + '});' + eol;
+};
+
+/////////////////////////////
+// for Jasmine or Mocha-Chai
+/////////////////////////////
+var _renderSingleTest = function(test, baseTemp) {
+  var base = baseTemp({
+    testTitle: test.testTitle,
+    assertions: test.assertions.length
+  });
+  return base + eol + _renderAssertions(test.assertions) + '});';
+};
+
+


### PR DESCRIPTION
Main points:
 - extracts redundant code from `speck.js` and puts it into helper functions in `template.utils` that are shared for all supported testing templates.
 - refactors comments and order of `template-utils` functions to be relatively consistent with logic flow in `speck.js#build` for easier comprehension.
 - refactor templates for proper formatting now that they share helper template-builder functions.